### PR TITLE
Updated Pulse.Public

### DIFF
--- a/pulses.go
+++ b/pulses.go
@@ -41,7 +41,7 @@ type Pulse struct {
 	Indicators        []PulseIndicator `json:"indicators,omitempty"`
 	Revision          float32          `json:"revision,omitempty"`
 	TLP               string           `json:"tlp"`
-	Public            bool             `json:"public"`
+	Public            int             `json:"public"`
 	Adversary         string           `json:"adversary"`
 	TargetedCountries []string         `json:"targeted_countries"`
 	Industries        []string         `json:"industries"`


### PR DESCRIPTION
For some reason the HTTP response now has a numeric Public property on the Pulse object which cannot be marshalled correctly.